### PR TITLE
記事詳細画面の実装

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -31,6 +31,7 @@ class ArticlesController < ApplicationController
 	end
 
 	def show
+		@article = Article.find(params[:id])
 	end
 
 	private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,5 @@
 class ArticlesController < ApplicationController
-	before_action :move_to_index, except: :index
+	before_action :move_to_index, except: [:index, :show]
 
 	def index
 		@articles = Article.all.order("created_at DESC")
@@ -28,6 +28,9 @@ class ArticlesController < ApplicationController
 		article = Article.find(params[:id])
 		article.destroy if article.user_id == current_user.id
 		redirect_to action: :index
+	end
+
+	def show
 	end
 
 	private

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -5,7 +5,7 @@
 				<%# <div class="card-content white-text"> %>
 				<div class="card-content">
 					<span class="card-title"><%= article.title %></span>
-					<%= simple_format(article.text) %>
+					<%= simple_format(article.text, class: "truncate") %>
 				</div>
 				<div class="card-action">
 					<a href="#">This is a link</a>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -8,7 +8,7 @@
 					<%= simple_format(article.text, class: "truncate") %>
 				</div>
 				<div class="card-action">
-					<a href="#">This is a link</a>
+					<%= link_to 'SHOW', article_path(article) %>
 					<% if user_signed_in? && article.user_id == current_user.id %>
 						<%= link_to 'EDIT', edit_article_path(article) %>
 						<%= link_to 'DELETE', article_path(article), method: :delete %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,0 +1,16 @@
+<div class="row valign-wrapper">
+	<div class="col s8 offset-s2 valign">
+		<div class="card grey lighten-5">
+			<div class="card-content">
+				<span class="card-title"><%= @article.title %></span>
+				<%= simple_format(@article.text) %>
+			</div>
+			<% if user_signed_in? && @article.user_id == current_user.id %>
+				<div class="card-action">
+					<%= link_to 'EDIT', edit_article_path(@article) %>
+					<%= link_to 'DELETE', article_path(@article), method: :delete %>
+				</div>
+			<% end %>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
# WHAT
記事の詳細表示画面を実装する。

# WHY
一覧画面に記事の全文を表示させるとスクロールが大変になるので、
記事全文は詳細画面を表示した際に確認できるようにし、
一覧画面では途中までの表示にする。